### PR TITLE
It needs PropertyChanged.Fody

### DIFF
--- a/.nuget/definitions/Xam.Plugins.VideoPlayer.nuspec
+++ b/.nuget/definitions/Xam.Plugins.VideoPlayer.nuspec
@@ -18,6 +18,7 @@
     <dependencies>
       <group>
         <dependency id="Xamarin.Forms" version="2.2.0.31" />
+        <dependency id="PropertyChanged.Fody" version="1.29.4" />
       </group>
     </dependencies>
   </metadata>


### PR DESCRIPTION
`samples/Xam.Plugins.VideoPlayer.Sample/ViewModels/VideoPlayerViewModel.cs` uses `[PropertyChanged.ImplementPropertyChanged]` attributes.
So, adding `dependency` is better.
